### PR TITLE
Use loadFeatures, writeTextRdd for cluster.

### DIFF
--- a/lime-cli/src/main/scala/org/bdgenomics/lime/cli/Cluster.scala
+++ b/lime-cli/src/main/scala/org/bdgenomics/lime/cli/Cluster.scala
@@ -19,10 +19,10 @@ package org.bdgenomics.lime.cli
 
 import org.apache.spark.SparkContext
 import org.bdgenomics.adam.rdd.ADAMContext._
-import org.bdgenomics.adam.rdd.ADAMSaveAnyArgs
+import org.bdgenomics.adam.util.TextRddWriter
 import org.bdgenomics.lime.op.ShuffleCluster
 import org.bdgenomics.utils.cli._
-import org.kohsuke.args4j.Argument
+import org.kohsuke.args4j.{ Argument, Option ⇒ Args4jOption }
 
 object Cluster extends BDGCommandCompanion {
   val commandName = "cluster"
@@ -32,31 +32,57 @@ object Cluster extends BDGCommandCompanion {
     new Cluster(Args4j[ClusterArgs](cmdLine))
   }
 
-  class ClusterArgs extends Args4jBase with ADAMSaveAnyArgs with ParquetArgs {
+  class ClusterArgs extends Args4jBase with ParquetSaveArgs {
     @Argument(required = true,
       metaVar = "INPUT",
-      usage = "The input file for cluster",
+      usage = "The features file to cluster (e.g., .bed, .gff/.gtf, .gff3, .interval_list, .narrowPeak). If extension is not detected, Parquet is assumed.",
       index = 0)
     var input: String = null
 
-    override var sortFastqOutput: Boolean = false
-    override var asSingleFile: Boolean = false
-    override var deferMerging: Boolean = false
-    override var outputPath: String = ""
-    override var disableFastConcat: Boolean = false
+    @Argument(required = false,
+      metaVar = "OUTPUT",
+      usage = "The output file for cluster, if any. If not specified, cluster will collect on the driver node and write to stdout.",
+      index = 1)
+    var outputPath: String = null
+
+    @Args4jOption(required = false,
+      name = "-num_partitions",
+      usage = "Number of partitions to use when loading the features file.")
+    var numPartitions: Int = _
+
+    @Args4jOption(required = false,
+      name = "-single",
+      usage = "Save as a single text file.")
+    var asSingleFile: Boolean = false
+
+    @Args4jOption(required = false,
+      name = "-disable_fast_concat",
+      usage = "Disables the parallel file concatenation engine.")
+    var disableFastConcat: Boolean = false
   }
 
   class Cluster(protected val args: ClusterArgs) extends BDGSparkCommand[ClusterArgs] {
     val companion = Intersection
 
     def run(sc: SparkContext) {
-      val leftGenomicRDD = sc.loadBed(args.input)
+      val leftGenomicRDD = sc.loadFeatures(
+        args.input,
+        optMinPartitions = Option(args.numPartitions),
+        optProjection = None)
 
-      ShuffleCluster(leftGenomicRDD)
+      val clusterRDD = ShuffleCluster(leftGenomicRDD)
         .compute()
         .rdd
-        .collect
-        .foreach(println)
+
+      Option(args.outputPath).fold(
+        clusterRDD
+          .collect
+          .foreach(println))(
+          TextRddWriter.writeTextRdd(
+            clusterRDD,
+            _,
+            asSingleFile = args.asSingleFile,
+            disableFastConcat = args.disableFastConcat))
     }
   }
 }

--- a/lime-cli/src/main/scala/org/bdgenomics/lime/cli/LimeMain.scala
+++ b/lime-cli/src/main/scala/org/bdgenomics/lime/cli/LimeMain.scala
@@ -28,6 +28,7 @@ private object LimeMain {
 
 private class LimeMain(args: Array[String]) extends Logging {
   private def commands: List[BDGCommandCompanion] = List(Complement,
+    Cluster,
     Intersection,
     Jaccard,
     Merge,


### PR DESCRIPTION
I've added an example of my suggestion in #37 to the cluster command.

Some further discussion on the output may be necessary, `bedtools cluster` writes out broken BED or GFF3 format (the extra column is not valid), depending on the format of the input file
```
$ bedtools cluster -i ../adam/adam-core/src/test/resources/dvl1.200.bed
1	1331345	1331536	106624	13.53	+	1
1	1331637	1331938	106625	61.9	+	2
1	1332023	1332806	106626	130.98	+	3
1	1332920	1333124	106627	35.31	+	4
...

$ bedtools cluster -i ../adam/adam-core/src/test/resources/dvl1.200.gff3
1	Ensembl	gene	1331314	1335306	.	+	.	ID=ENSG00000169962;Name=ENSG00000169962;biotype=protein_coding	1
1	Ensembl	gene	1335276	1349350	.	-	.	ID=ENSG00000107404;Name=ENSG00000107404;biotype=protein_coding	1
1	Ensembl	gene	1339650	1339708	.	-	.	ID=ENSG00000275884;Name=ENSG00000275884;biotype=miRNA	1
1	Ensembl	gene	1352689	1361777	.	-	.	ID=ENSG00000162576;Name=ENSG00000162576;biotype=protein_coding	2
...
```

Lime `Cluster` writes out string representations of the join, which are JSON tuples of (Feature, List[Feature]).
```
({"featureId": null, "name": "rs142864514", "source": null, "featureType": null, "contigName": "1", "start": 1331046, "end": 1331047, "strand": "FORWARD", "phase": null, "frame": null, "score": 0.0, "geneId": null, "transcriptId": null, "exonId": null, "aliases": [], "parentIds": [], "target": null, "gap": null, "derivesFrom": null, "notes": [], "dbxrefs": [], "ontologyTerms": [], "circular": null, "attributes": {}},
  List(
    {"featureId": null, "name": "rs142864514", "source": null, "featureType": null, "contigName": "1", "start": 1331046, "end": 1331047, "strand": "FORWARD", "phase": null, "frame": null, "score": 0.0, "geneId": null, "transcriptId": null, "exonId": null, "aliases": [], "parentIds": [], "target": null, "gap": null, "derivesFrom": null, "notes": [], "dbxrefs": [], "ontologyTerms": [], "circular": null, "attributes": {}}))

({"featureId": null, "name": "rs369337190", "source": null, "featureType": null, "contigName": "1", "start": 1331304, "end": 1331305, "strand": "FORWARD", "phase": null, "frame": null, "score": 0.0, "geneId": null, "transcriptId": null, "exonId": null, "aliases": [], "parentIds": [], "target": null, "gap": null, "derivesFrom": null, "notes": [], "dbxrefs": [], "ontologyTerms": [], "circular": null, "attributes": {}},
  List(
    {"featureId": null, "name": "rs369337190", "source": null, "featureType": null, "contigName": "1", "start": 1331304, "end": 1331305, "strand": "FORWARD", "phase": null, "frame": null, "score": 0.0, "geneId": null, "transcriptId": null, "exonId": null, "aliases": [], "parentIds": [], "target": null, "gap": null, "derivesFrom": null, "notes": [], "dbxrefs": [], "ontologyTerms": [], "circular": null, "attributes": {}},
    {"featureId": null, "name": "rs761505738", "source": null, "featureType": null, "contigName": "1", "start": 1331304, "end": 1331305, "strand": "FORWARD", "phase": null, "frame": null, "score": 0.0, "geneId": null, "transcriptId": null, "exonId": null, "aliases": [], "parentIds": [], "target": null, "gap": null, "derivesFrom": null, "notes": [], "dbxrefs": [], "ontologyTerms": [], "circular": null, "attributes": {}}))
...
```

There are a few different things we could do with the output, my suggestion would be to create a `cluster=n` attribute similar to the extra bedtools column and then use `FeatureRDD.save` to support all the ADAM output formats.

When loading from Parquet, we may also want to add an `-limited_projection` command line option to only project those fields necessary for the cluster operation.

Finally, bedtools cluster provides a `-d` option, to specify how close two features must be in order to cluster.  `ShuffleCluster` has a similar `threshold` ctr parameter.